### PR TITLE
fixes for libresolv bugs exposed by CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,7 +8,7 @@ env:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-16.04
 
     steps:
     - uses: actions/checkout@v2

--- a/src/resolver/libresolv/ffi.rs
+++ b/src/resolver/libresolv/ffi.rs
@@ -81,12 +81,12 @@ pub fn ns_msg_count(
 }
 
 pub use libresolv_sys::__dn_expand as dn_expand;
-pub use libresolv_sys::__ns_class_ns_c_any as ns_c_any;
+pub use libresolv_sys::__ns_class_ns_c_in as ns_c_in;
 pub use libresolv_sys::__ns_sect_ns_s_an as ns_s_an;
 pub use libresolv_sys::__ns_type_ns_t_srv as ns_t_srv;
 pub use libresolv_sys::__res_nclose as res_nclose;
 pub use libresolv_sys::__res_ninit as res_ninit;
-pub use libresolv_sys::__res_nquery as res_nquery;
+pub use libresolv_sys::__res_nsearch as res_nsearch;
 pub use libresolv_sys::__res_state as res_state;
 pub use libresolv_sys::ns_initparse;
 pub use libresolv_sys::ns_msg;


### PR DESCRIPTION
* Changes LibResolv to ask for DNS records in the IN class instead of the ANY class. Turns out some but not all DNS servers let you get away with asking for ANY.
* Stops the client from trying again with a larger buffer on TRY_AGAIN since it is actually the sign of a DNS server failure.
* Switches from res_nquery to res_nsearch since it adds a bit of functionality.
* Switches Github Actions to Ubuntu 16.04 since DNS lookups on 18.04 were being buggy and returning SERVFAIL (can't reproduce on the devices I have access to).