### PR TITLE
Execute methods and concurrent execution mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,10 @@ log = ["tracing"]
 [dependencies]
 arc-swap = "^0.4"
 async-trait = "^0.1"
+futures-util = "^0.3"
 http = "^0.2"
 libresolv-sys = { version = "^0.2", optional = true }
+pin-utils = "^0.1"
 rand = "^0.7"
 thiserror = "^1"
 tracing = { version = "^0.1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ async-trait = "^0.1"
 futures-util = "^0.3"
 http = "^0.2"
 libresolv-sys = { version = "^0.2", optional = true }
-pin-project = "^0.4"
 rand = "^0.7"
 thiserror = "^1"
 tracing = { version = "^0.1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ tracing = { version = "^0.1", optional = true }
 
 [dev-dependencies]
 criterion = "^0.3"
+futures = "^0.3"
 hyper = "^0.13"
 tokio = { version = "^0.2", features = ["rt-threaded", "macros"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ async-trait = "^0.1"
 futures-util = "^0.3"
 http = "^0.2"
 libresolv-sys = { version = "^0.2", optional = true }
-pin-utils = "^0.1"
+pin-project = "^0.4"
 rand = "^0.7"
 thiserror = "^1"
 tracing = { version = "^0.1", optional = true }

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ first `Ok` or last `Err` it obtains.
 
 ## Alternative Resolvers and Target Selection Policies
 
-By default, `srv-rs` makes use of `libresolv` for SRV lookup and uses a
+`srv-rs` provides a `libresolv`-based resolver for SRV lookup and by default uses a
 target selection policy that maintains affinity for the last target it has used
 successfully. Both of these behaviors can be changed by implementing the
 [`SrvResolver`] and [`Policy`] traits, respectively.

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ selection of targets to use for communication with SRV-located services.
 It presents this service in the following interface:
 
 ```rust
-use srv_rs::{client::SrvClient, resolver::libresolv::LibResolv};
+use srv_rs::{client::{SrvClient, Execution}, resolver::libresolv::LibResolv};
 let client = SrvClient::<LibResolv>::new("_http._tcp.example.com");
-srv_rs::execute!(client, |address: http::Uri| async move {
+client.execute_one(Execution::Serial, |address: http::Uri| async move {
     // Communicate with the service at `address`
     // `hyper` is used here as an example, but it is in no way required
     hyper::Client::new().get(address).await

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ It presents this service in the following interface:
 ```rust
 use srv_rs::{client::{SrvClient, Execution}, resolver::libresolv::LibResolv};
 let client = SrvClient::<LibResolv>::new("_http._tcp.example.com");
-client.execute_one(Execution::Serial, |address: http::Uri| async move {
+client.execute(Execution::Serial, |address: http::Uri| async move {
     // Communicate with the service at `address`
     // `hyper` is used here as an example, but it is in no way required
     hyper::Client::new().get(address).await
@@ -40,7 +40,7 @@ client.execute_one(Execution::Serial, |address: http::Uri| async move {
 
 [`SrvClient::new`] creates a client (that should be reused to take advantage of
 caching) for communicating with the service located by `_http._tcp.example.com`.
-[`SrvClient::execute_one`] takes in a future-producing closure (emulating async
+[`SrvClient::execute`] takes in a future-producing closure (emulating async
 closures, which are currently unstable) and executes the closure on a series of
 targets parsed from the discovered SRV records, stopping and returning the
 first `Ok` or last `Err` it obtains.
@@ -53,7 +53,7 @@ successfully. Both of these behaviors can be changed by implementing the
 [`SrvResolver`] and [`Policy`] traits, respectively.
 
 [`SrvClient::new`]: client/struct.SrvClient.html#method.new
-[`SrvClient::execute_one`]: client/struct.SrvClient.html#method.execute_one
+[`SrvClient::execute`]: client/struct.SrvClient.html#method.execute
 [`SrvResolver`]: resolver/trait.SrvResolver.html
 [`Policy`]: client/policy/trait.Policy.html
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ srv_rs::execute!(client, |address: http::Uri| async move {
     // Communicate with the service at `address`
     // `hyper` is used here as an example, but it is in no way required
     hyper::Client::new().get(address).await
-}).await;
+})
+.await;
 ```
 
 [`SrvClient::new`] creates a client (that should be reused to take advantage of

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ client.execute_one(Execution::Serial, |address: http::Uri| async move {
 
 [`SrvClient::new`] creates a client (that should be reused to take advantage of
 caching) for communicating with the service located by `_http._tcp.example.com`.
-The [`execute`] macro takes in a future-producing closure (emulating async
+[`SrvClient::execute_one`] takes in a future-producing closure (emulating async
 closures, which are currently unstable) and executes the closure on a series of
 targets parsed from the discovered SRV records, stopping and returning the
 first `Ok` or last `Err` it obtains.
@@ -53,7 +53,7 @@ successfully. Both of these behaviors can be changed by implementing the
 [`SrvResolver`] and [`Policy`] traits, respectively.
 
 [`SrvClient::new`]: client/struct.SrvClient.html#method.new
-[`execute`]: macro.execute.html
+[`SrvClient::execute_one`]: client/struct.SrvClient.html#method.execute_one
 [`SrvResolver`]: resolver/trait.SrvResolver.html
 [`Policy`]: client/policy/trait.Policy.html
 

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ For instance, a DNS server might respond with the following SRV records for
 `_http._tcp.example.com`:
 
 ```
-_http._tcp.example.com. 60 IN SRV 1 100 8000 test.example.com.
-_http._tcp.example.com. 60 IN SRV 2 50  8001 test.example.com.
-_http._tcp.example.com. 60 IN SRV 2 50  8002 test.example.com.
+_http._tcp.example.com. 60 IN SRV 1 100 443 test1.example.com.
+_http._tcp.example.com. 60 IN SRV 2 50  443 test2.example.com.
+_http._tcp.example.com. 60 IN SRV 2 50  443 test3.example.com.
 ```
 
 A client wanting to communicate with this example service would first try to
-communicate with `test.example.com:8000` (the record with the lowest
+communicate with `test1.example.com:443` (the record with the lowest
 priority), then with the other two (in a random order, since they are of the
 same priority) should the first be unavailable.
 

--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ It presents this service in the following interface:
 ```rust
 use srv_rs::{client::SrvClient, resolver::libresolv::LibResolv};
 let client = SrvClient::<LibResolv>::new("_http._tcp.example.com");
-srv_rs::execute!(client, |address: &http::Uri| async move {
+srv_rs::execute!(client, |address: http::Uri| async move {
     // Communicate with the service at `address`
     // `hyper` is used here as an example, but it is in no way required
-    hyper::Client::new().get(address.to_owned()).await
+    hyper::Client::new().get(address).await
 }).await;
 ```
 

--- a/benches/client.rs
+++ b/benches/client.rs
@@ -25,33 +25,31 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
     let mut group = c.benchmark_group(format!("execute ({}, first succeeds)", SRV_DESCRIPTION));
     group.bench_function("Policy::Affinity", |b| {
-        b.iter(|| runtime.block_on(client.execute_one(Execution::Serial, |_| async { succeed() })))
+        b.iter(|| runtime.block_on(client.execute(Execution::Serial, |_| async { succeed() })))
     });
     group.bench_function("Policy::Rfc2782", |b| {
         b.iter(|| {
-            runtime.block_on(rfc2782_client.execute_one(Execution::Serial, |_| async { succeed() }))
+            runtime.block_on(rfc2782_client.execute(Execution::Serial, |_| async { succeed() }))
         })
     });
     drop(group);
 
     let mut group = c.benchmark_group(format!("execute ({}, all fail)", SRV_DESCRIPTION));
     group.bench_function("Policy::Affinity", |b| {
-        b.iter(|| runtime.block_on(client.execute_one(Execution::Serial, |_| async { fail() })))
+        b.iter(|| runtime.block_on(client.execute(Execution::Serial, |_| async { fail() })))
     });
     group.bench_function("Policy::Rfc2782", |b| {
-        b.iter(|| {
-            runtime.block_on(rfc2782_client.execute_one(Execution::Serial, |_| async { fail() }))
-        })
+        b.iter(|| runtime.block_on(rfc2782_client.execute(Execution::Serial, |_| async { fail() })))
     });
     drop(group);
 
     let mut group = c.benchmark_group(format!("execute ({}, half fail)", SRV_DESCRIPTION));
     group.bench_function("Policy::Affinity", |b| {
-        b.iter(|| runtime.block_on(client.execute_one(Execution::Serial, |_| async { random() })))
+        b.iter(|| runtime.block_on(client.execute(Execution::Serial, |_| async { random() })))
     });
     group.bench_function("Policy::Rfc2782", |b| {
         b.iter(|| {
-            runtime.block_on(rfc2782_client.execute_one(Execution::Serial, |_| async { random() }))
+            runtime.block_on(rfc2782_client.execute(Execution::Serial, |_| async { random() }))
         })
     });
 }

--- a/benches/client.rs
+++ b/benches/client.rs
@@ -1,8 +1,7 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use rand::Rng;
 use srv_rs::{
-    client::{policy::Rfc2782, SrvClient},
-    execute,
+    client::{policy::Rfc2782, Execution, SrvClient},
     resolver::libresolv::LibResolv,
 };
 
@@ -26,28 +25,34 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
     let mut group = c.benchmark_group(format!("execute ({}, first succeeds)", SRV_DESCRIPTION));
     group.bench_function("Policy::Affinity", |b| {
-        b.iter(|| runtime.block_on(execute!(client, |_| async { succeed() })))
+        b.iter(|| runtime.block_on(client.execute_one(Execution::Serial, |_| async { succeed() })))
     });
     group.bench_function("Policy::Rfc2782", |b| {
-        b.iter(|| runtime.block_on(execute!(rfc2782_client, |_| async { succeed() })))
+        b.iter(|| {
+            runtime.block_on(rfc2782_client.execute_one(Execution::Serial, |_| async { succeed() }))
+        })
     });
     drop(group);
 
     let mut group = c.benchmark_group(format!("execute ({}, all fail)", SRV_DESCRIPTION));
     group.bench_function("Policy::Affinity", |b| {
-        b.iter(|| runtime.block_on(execute!(client, |_| async { fail() })))
+        b.iter(|| runtime.block_on(client.execute_one(Execution::Serial, |_| async { fail() })))
     });
     group.bench_function("Policy::Rfc2782", |b| {
-        b.iter(|| runtime.block_on(execute!(rfc2782_client, |_| async { fail() })))
+        b.iter(|| {
+            runtime.block_on(rfc2782_client.execute_one(Execution::Serial, |_| async { fail() }))
+        })
     });
     drop(group);
 
     let mut group = c.benchmark_group(format!("execute ({}, half fail)", SRV_DESCRIPTION));
     group.bench_function("Policy::Affinity", |b| {
-        b.iter(|| runtime.block_on(execute!(client, |_| async { random() })))
+        b.iter(|| runtime.block_on(client.execute_one(Execution::Serial, |_| async { random() })))
     });
     group.bench_function("Policy::Rfc2782", |b| {
-        b.iter(|| runtime.block_on(execute!(rfc2782_client, |_| async { random() })))
+        b.iter(|| {
+            runtime.block_on(rfc2782_client.execute_one(Execution::Serial, |_| async { random() }))
+        })
     });
 }
 

--- a/benches/client.rs
+++ b/benches/client.rs
@@ -6,7 +6,7 @@ use srv_rs::{
     resolver::libresolv::LibResolv,
 };
 
-const SRV_NAME: &str = "_http._tcp.srv-client-rust.deshaw.org";
+const SRV_NAME: &str = srv_rs::EXAMPLE_SRV;
 const SRV_DESCRIPTION: &str = SRV_NAME;
 
 pub fn criterion_benchmark(c: &mut Criterion) {

--- a/benches/resolver.rs
+++ b/benches/resolver.rs
@@ -5,14 +5,11 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     let mut runtime = tokio::runtime::Runtime::new().unwrap();
 
     c.bench_function(
-        "resolve _http._tcp.srv-client-rust.deshaw.org (libresolv)",
+        &format!("resolve {} (libresolv)", srv_rs::EXAMPLE_SRV),
         |b| {
             b.iter(|| {
                 runtime
-                    .block_on(
-                        LibResolv::default()
-                            .get_srv_records_unordered("_http._tcp.srv-client-rust.deshaw.org"),
-                    )
+                    .block_on(LibResolv::default().get_srv_records_unordered(srv_rs::EXAMPLE_SRV))
                     .unwrap()
             })
         },
@@ -27,12 +24,10 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     });
 
     let records = runtime
-        .block_on(
-            LibResolv::default().get_srv_records_unordered("_http._tcp.srv-client-rust.deshaw.org"),
-        )
+        .block_on(LibResolv::default().get_srv_records_unordered(srv_rs::EXAMPLE_SRV))
         .unwrap();
     let mut rng = rand::thread_rng();
-    c.bench_function("order _http._tcp.srv-client-rust.deshaw.org records", |b| {
+    c.bench_function(&format!("order {} records", srv_rs::EXAMPLE_SRV), |b| {
         b.iter(|| LibResolv::order_srv_records(&mut records.clone(), &mut rng))
     });
 }

--- a/src/client/cache.rs
+++ b/src/client/cache.rs
@@ -28,8 +28,8 @@ impl<T> Cache<T> {
         !self.items.is_empty() && self.created.elapsed() <= self.max_age
     }
 
-    pub fn items<'a>(guard: Guard<'a, Arc<Self>>) -> CacheItemsHandle<T> {
-        CacheItemsHandle(guard)
+    pub fn items(&self) -> &[T] {
+        &self.items
     }
 }
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -21,11 +21,11 @@ pub mod policy;
 /// Errors encountered during SRV record resolution
 #[derive(Debug, thiserror::Error)]
 pub enum SrvError<Lookup: Debug> {
-    /// Srv lookup errors
-    #[error("srv lookup error")]
+    /// SRV lookup errors
+    #[error("SRV lookup error")]
     Lookup(Lookup),
-    /// Srv record parsing errors
-    #[error("building uri from srv record: {0}")]
+    /// SRV record parsing errors
+    #[error("building uri from SRV record: {0}")]
     RecordParsing(#[from] http::Error),
     /// Produced when there are no SRV targets for a client to use
     #[error("no SRV targets to use")]

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -34,13 +34,30 @@ pub enum SrvError<Lookup: Debug> {
 
 /// Client for intelligently performing operations on a service located by SRV records.
 ///
+/// # Usage
+///
+/// After being created by [`new`] or [`new_with_resolver`], operations can be
+/// performed on the service pointed to by a `SrvClient` with the [`execute`]
+/// and [`execute_one`] methods.
+///
+/// ## DNS Resolvers
+///
+/// The resolver used to lookup SRV records is determined by a client's
+/// [`SrvResolver`], and can be set with [`resolver`].
+///
 /// ## SRV Target Selection Policies
 ///
 /// SRV target selection order is determined by a client's [`Policy`],
-/// and can be set with [`SrvClient::policy`].
+/// and can be set with [`policy`].
 ///
+/// [`new`]: struct.SrvClient.html#method.new
+/// [`new_with_resolver`]: struct.SrvClient.html#method.new_with_resolver
+/// [`execute`]: struct.SrvClient.html#method.execute
+/// [`execute_one`]: struct.SrvClient.html#method.execute_one
+/// [`SrvResolver`]: ../resolver/trait.SrvResolver.html
+/// [`resolver`]: struct.SrvClient.html#method.resolver
 /// [`Policy`]: policy/trait.Policy.html
-/// [`SrvClient::policy`]: struct.SrvClient.html#method.policy
+/// [`policy`]: struct.SrvClient.html#method.policy
 #[derive(Debug)]
 pub struct SrvClient<Resolver, Policy: policy::Policy = policy::Affinity> {
     srv: String,

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -86,7 +86,9 @@ impl<Resolver: SrvResolver, Policy: policy::Policy + Default> SrvClient<Resolver
             cache: Default::default(),
         }
     }
+}
 
+impl<Resolver: SrvResolver, Policy: policy::Policy> SrvClient<Resolver, Policy> {
     async fn get_srv_records(&self) -> Result<Vec<Resolver::Record>, SrvError<Resolver::Error>> {
         self.resolver
             .get_srv_records(&self.srv)

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -66,9 +66,7 @@ impl Default for Execution {
     }
 }
 
-impl<Resolver: SrvResolver + Default, Policy: policy::Policy + Default>
-    SrvClient<Resolver, Policy>
-{
+impl<Resolver: Default, Policy: policy::Policy + Default> SrvClient<Resolver, Policy> {
     /// Creates a new client for communicating with services located by `srv_name`.
     ///
     /// # Examples
@@ -83,7 +81,7 @@ impl<Resolver: SrvResolver + Default, Policy: policy::Policy + Default>
     }
 }
 
-impl<Resolver: SrvResolver, Policy: policy::Policy + Default> SrvClient<Resolver, Policy> {
+impl<Resolver, Policy: policy::Policy + Default> SrvClient<Resolver, Policy> {
     /// Creates a new client for communicating with services located by `srv_name`.
     pub fn new_with_resolver(srv_name: impl ToString, resolver: Resolver) -> Self {
         Self {
@@ -265,7 +263,9 @@ impl<Resolver: SrvResolver, Policy: policy::Policy> SrvClient<Resolver, Policy> 
     fn parse_record(&self, record: &Resolver::Record) -> Result<Uri, http::Error> {
         record.parse(self.http_scheme.clone(), self.path_prefix.as_str())
     }
+}
 
+impl<Resolver, Policy: policy::Policy> SrvClient<Resolver, Policy> {
     /// Sets the SRV name of the client.
     pub fn srv_name(self, srv_name: impl ToString) -> Self {
         Self {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -154,8 +154,13 @@ impl<Resolver: SrvResolver, Policy: policy::Policy> SrvClient<Resolver, Policy> 
         }
     }
 
-    /// Performs an operation on a client's SRV targets, producing a stream of
-    /// results.
+    /// Performs an operation on all of a client's SRV targets, producing a
+    /// stream of results (one for each target). If the serial execution mode is
+    /// specified, the operation will be performed on each target in the order
+    /// determined by the current [`Policy`], and the results will be returned
+    /// in the same order. If the concurrent execution mode is specified, the
+    /// operation will be performed on all targets concurrently, and results
+    /// will be returned in the order they become available.
     ///
     /// # Examples
     ///
@@ -179,6 +184,8 @@ impl<Resolver: SrvResolver, Policy: policy::Policy> SrvClient<Resolver, Policy> 
     /// # Ok(())
     /// # }
     /// ```
+    ///
+    /// [`Policy`]: policy/trait.Policy.html
     pub async fn execute<'a, T, E: Error, Fut>(
         &'a self,
         execution_mode: Execution,

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -234,13 +234,13 @@ impl<Resolver: SrvResolver, Policy: policy::Policy> SrvClient<Resolver, Policy> 
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn execute_one<'a, T, E: Error, Fut>(
-        &'a self,
+    pub async fn execute_one<T, E: Error, Fut>(
+        &self,
         execution_mode: Execution,
-        func: impl FnMut(Uri) -> Fut + 'a,
+        func: impl FnMut(Uri) -> Fut,
     ) -> Result<Result<T, E>, SrvError<Resolver::Error>>
     where
-        Fut: Future<Output = Result<T, E>> + 'a,
+        Fut: Future<Output = Result<T, E>>,
     {
         let results = self.execute(execution_mode, func).await?;
         pin_mut!(results);

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -28,15 +28,9 @@ pub enum SrvError<Lookup: Debug> {
     #[error("building uri from srv record: {0}")]
     RecordParsing(#[from] http::Error),
     /// Produced when there are no SRV targets for a client to use
-    #[error(transparent)]
-    NoTargets(#[from] NoSRVTargets),
+    #[error("no SRV targets to use")]
+    NoTargets,
 }
-
-/// Error produced when there are no SRV targets to use--i.e., when no SRV
-/// records were found.
-#[derive(Debug, thiserror::Error)]
-#[error("no SRV targets to use")]
-pub struct NoSRVTargets;
 
 /// Client for intelligently performing operations on a service located by SRV records.
 ///
@@ -264,7 +258,7 @@ impl<Resolver: SrvResolver, Policy: policy::Policy> SrvClient<Resolver, Policy> 
         if let Some(err) = last_error {
             Ok(Err(err))
         } else {
-            Err(NoSRVTargets.into())
+            Err(SrvError::NoTargets)
         }
     }
 

--- a/src/client/policy.rs
+++ b/src/client/policy.rs
@@ -2,7 +2,7 @@ use crate::client::{Cache, SrvClient, SrvError, SrvRecord, SrvResolver};
 use arc_swap::ArcSwapOption;
 use async_trait::async_trait;
 use http::Uri;
-use std::{marker::PhantomData, sync::Arc};
+use std::sync::Arc;
 
 /// Policy for [`SrvClient`] to use when selecting SRV targets to recommend.
 ///
@@ -178,30 +178,6 @@ impl Policy for Rfc2782 {
 
     fn cache_item_to_uri(item: &Self::CacheItem) -> &Uri {
         &item.uri
-    }
-}
-
-/// Iterator over `Uri`s with order determined by the algorithm in RFC 2782.
-/// See [`Rfc2782`].
-///
-/// [`Rfc2782`]: struct.Rfc2782.html
-pub struct Rfc2782UriIter<'a, Uris, Order> {
-    lifetime: PhantomData<&'a ()>,
-    uris: Uris,
-    order: Order,
-}
-
-impl<'a, Uris, Order> Iterator for Rfc2782UriIter<'a, Uris, Order>
-where
-    Uris: AsRef<[ParsedRecord]>,
-    Order: Iterator<Item = usize>,
-{
-    type Item = &'a Uri;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let idx = self.order.next()?;
-        let uri = self.uris.as_ref().get(idx).map(|parsed| &parsed.uri);
-        unsafe { std::mem::transmute(uri) }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@ first `Ok` or last `Err` it obtains.
 
 # Alternative Resolvers and Target Selection Policies
 
-By default, `srv-rs` makes use of `libresolv` for SRV lookup and uses a
+`srv-rs` provides a `libresolv`-based resolver for SRV lookup and by default uses a
 target selection policy that maintains affinity for the last target it has used
 successfully. Both of these behaviors can be changed by implementing the
 [`SrvResolver`] and [`Policy`] traits, respectively.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![warn(missing_docs)]
+#![deny(missing_docs)]
 
 /*!
 Rust client for communicating with services located by DNS SRV records.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,8 @@ srv_rs::execute!(client, |address: http::Uri| async move {
     // Communicate with the service at `address`
     // `hyper` is used here as an example, but it is in no way required
     hyper::Client::new().get(address).await
-}).await;
+})
+.await;
 # }
 ```
 
@@ -66,3 +67,6 @@ pub mod client;
 pub mod record;
 
 pub mod resolver;
+
+#[doc(hidden)]
+pub const EXAMPLE_SRV: &str = "_http._tcp.srv-client-rust.deshaw.org";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ It presents this service in the following interface:
 # async fn main() {
 use srv_rs::{client::{SrvClient, Execution}, resolver::libresolv::LibResolv};
 let client = SrvClient::<LibResolv>::new("_http._tcp.example.com");
-client.execute_one(Execution::Serial, |address: http::Uri| async move {
+client.execute(Execution::Serial, |address: http::Uri| async move {
     // Communicate with the service at `address`
     // `hyper` is used here as an example, but it is in no way required
     hyper::Client::new().get(address).await
@@ -44,7 +44,7 @@ client.execute_one(Execution::Serial, |address: http::Uri| async move {
 
 [`SrvClient::new`] creates a client (that should be reused to take advantage of
 caching) for communicating with the service located by `_http._tcp.example.com`.
-[`SrvClient::execute_one`] takes in a future-producing closure (emulating async
+[`SrvClient::execute`] takes in a future-producing closure (emulating async
 closures, which are currently unstable) and executes the closure on a series of
 targets parsed from the discovered SRV records, stopping and returning the
 first `Ok` or last `Err` it obtains.
@@ -57,7 +57,7 @@ successfully. Both of these behaviors can be changed by implementing the
 [`SrvResolver`] and [`Policy`] traits, respectively.
 
 [`SrvClient::new`]: client/struct.SrvClient.html#method.new
-[`SrvClient::execute_one`]: client/struct.SrvClient.html#method.execute_one
+[`SrvClient::execute`]: client/struct.SrvClient.html#method.execute
 [`SrvResolver`]: resolver/trait.SrvResolver.html
 [`Policy`]: client/policy/trait.Policy.html
 */

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,13 +14,13 @@ For instance, a DNS server might respond with the following SRV records for
 `_http._tcp.example.com`:
 
 ```text
-_http._tcp.example.com. 60 IN SRV 1 100 8000 test.example.com.
-_http._tcp.example.com. 60 IN SRV 2 50  8001 test.example.com.
-_http._tcp.example.com. 60 IN SRV 2 50  8002 test.example.com.
+_http._tcp.example.com. 60 IN SRV 1 100 443 test1.example.com.
+_http._tcp.example.com. 60 IN SRV 2 50  443 test2.example.com.
+_http._tcp.example.com. 60 IN SRV 2 50  443 test3.example.com.
 ```
 
 A client wanting to communicate with this example service would first try to
-communicate with `test.example.com:8000` (the record with the lowest
+communicate with `test1.example.com:443` (the record with the lowest
 priority), then with the other two (in a random order, since they are of the
 same priority) should the first be unavailable.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(missing_docs)]
+#![warn(missing_docs)]
 
 /*!
 Rust client for communicating with services located by DNS SRV records.
@@ -33,10 +33,10 @@ It presents this service in the following interface:
 # async fn main() {
 use srv_rs::{client::SrvClient, resolver::libresolv::LibResolv};
 let client = SrvClient::<LibResolv>::new("_http._tcp.example.com");
-srv_rs::execute!(client, |address: &http::Uri| async move {
+srv_rs::execute!(client, |address: http::Uri| async move {
     // Communicate with the service at `address`
     // `hyper` is used here as an example, but it is in no way required
-    hyper::Client::new().get(address.to_owned()).await
+    hyper::Client::new().get(address).await
 }).await;
 # }
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ client.execute_one(Execution::Serial, |address: http::Uri| async move {
 
 [`SrvClient::new`] creates a client (that should be reused to take advantage of
 caching) for communicating with the service located by `_http._tcp.example.com`.
-The [`execute`] macro takes in a future-producing closure (emulating async
+[`SrvClient::execute_one`] takes in a future-producing closure (emulating async
 closures, which are currently unstable) and executes the closure on a series of
 targets parsed from the discovered SRV records, stopping and returning the
 first `Ok` or last `Err` it obtains.
@@ -57,7 +57,7 @@ successfully. Both of these behaviors can be changed by implementing the
 [`SrvResolver`] and [`Policy`] traits, respectively.
 
 [`SrvClient::new`]: client/struct.SrvClient.html#method.new
-[`execute`]: macro.execute.html
+[`SrvClient::execute_one`]: client/struct.SrvClient.html#method.execute_one
 [`SrvResolver`]: resolver/trait.SrvResolver.html
 [`Policy`]: client/policy/trait.Policy.html
 */

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,9 +31,9 @@ It presents this service in the following interface:
 ```
 # #[tokio::main]
 # async fn main() {
-use srv_rs::{client::SrvClient, resolver::libresolv::LibResolv};
+use srv_rs::{client::{SrvClient, Execution}, resolver::libresolv::LibResolv};
 let client = SrvClient::<LibResolv>::new("_http._tcp.example.com");
-srv_rs::execute!(client, |address: http::Uri| async move {
+client.execute_one(Execution::Serial, |address: http::Uri| async move {
     // Communicate with the service at `address`
     // `hyper` is used here as an example, but it is in no way required
     hyper::Client::new().get(address).await

--- a/src/resolver/libresolv/mod.rs
+++ b/src/resolver/libresolv/mod.rs
@@ -190,7 +190,7 @@ mod tests {
     #[tokio::test]
     async fn test_srv_lookup() -> Result<(), LibResolvError> {
         let records = LibResolv::default()
-            .get_srv_records_unordered("_http._tcp.srv-client-rust.deshaw.org")
+            .get_srv_records_unordered(crate::EXAMPLE_SRV)
             .await?;
         assert_ne!(records.len(), 0);
         Ok(())
@@ -199,7 +199,7 @@ mod tests {
     #[tokio::test]
     async fn test_srv_lookup_ordered() -> Result<(), LibResolvError> {
         let records = LibResolv::default()
-            .get_srv_records("_http._tcp.srv-client-rust.deshaw.org")
+            .get_srv_records(crate::EXAMPLE_SRV)
             .await?;
         assert_ne!(records.len(), 0);
         assert!((0..records.len() - 1).all(|i| records[i].priority() <= records[i + 1].priority()));


### PR DESCRIPTION
* Changes `execute` from being a macro to being a pair of methods: one that produces a stream of results (`SrvClient::execute`) and one that picks out the first successful one (`SrvClient::execute_one`)
  * Suggestions for better names for `SrvClient::execute_one` are welcome
* Adds a concurrent execution mode as an alternative to the existing serial mode
* Changes iterators returned by SRV selection policies to produce indices into a cache instead of references, which alleviates much of the previous lifetime pain caused by lack of GATs