### PR TITLE
trust-dns support

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,10 +14,12 @@ jobs:
         run: cargo build --verbose --no-default-features
       - name: Build (default features)
         run: cargo build --verbose
+      - name: Build (all features)
+        run: cargo build --verbose --all-features
       - name: Run tests
-        run: cargo test --verbose
+        run: cargo test --verbose --all-features
       - name: Compile benchmarks
-        run: cargo bench --no-run
+        run: cargo bench --no-run --all-features
 
   rustfmt:
     runs-on: ubuntu-16.04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.1.0 - 2020-09-18
+## 0.1.0 - 2020-10-22
 
 ### Added
 
--   Abstraction of SRV records
--   Abstraction of SRV DNS resolvers
--   `libresolv`-based resolver
--   Client for communicating with SRV-located services
--   Abstraction of SRV target selection policies
+- Abstraction of SRV records
+- Abstraction of SRV DNS resolvers
+  - `libresolv` and `trust-dns`-based implementations
+- Abstraction of SRV target selection policies
+- Client for communicating with SRV-located services

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ default = ["libresolv", "log"]
 
 libresolv = ["libresolv-sys"]
 log = ["tracing"]
+trust-dns = ["trust-dns-resolver"]
 
 [dependencies]
 arc-swap = "^0.4"
@@ -28,6 +29,7 @@ libresolv-sys = { version = "^0.2", optional = true }
 rand = "^0.7"
 thiserror = "^1"
 tracing = { version = "^0.1", optional = true }
+trust-dns-resolver = { version = "^0.19", optional = true }
 
 [dev-dependencies]
 criterion = "^0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["network-programming"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["libresolv", "log"]
+default = ["log"]
 
 libresolv = ["libresolv-sys"]
 log = ["tracing"]

--- a/README.md
+++ b/README.md
@@ -47,23 +47,32 @@ first `Ok` or last `Err` it obtains.
 
 ## Alternative Resolvers and Target Selection Policies
 
-`srv-rs` provides a `libresolv`-based resolver for SRV lookup and by default uses a
-target selection policy that maintains affinity for the last target it has used
-successfully. Both of these behaviors can be changed by implementing the
+`srv-rs` provides multiple resolver backends for SRV lookup and by default uses
+a target selection policy that maintains affinity for the last target it has
+used successfully. Both of these behaviors can be changed by implementing the
 [`SrvResolver`] and [`Policy`] traits, respectively.
 
-[`SrvClient::new`]: client/struct.SrvClient.html#method.new
-[`SrvClient::execute`]: client/struct.SrvClient.html#method.execute
-[`SrvResolver`]: resolver/trait.SrvResolver.html
-[`Policy`]: client/policy/trait.Policy.html
+The provided resolver backends are enabled by the following features:
+
+- `libresolv` (via [`LibResolv`])
+- `trust-dns` (via [`trust-dns-resolver::AsyncResolver`])
+
+[`srvclient::new`]: client/struct.SrvClient.html#method.new
+[`srvclient::execute`]: client/struct.SrvClient.html#method.execute
+[`srvresolver`]: resolver/trait.SrvResolver.html
+[`policy`]: client/policy/trait.Policy.html
+[`libresolv`]: resolver/libresolv/struct.LibResolv.html
+[`trust-dns-resolver::asyncresolver`]: ../trust_dns_resolver/struct.AsyncResolver.html
 
 ## Usage
 
-Add srv-rs to your dependencies in `Cargo.toml`:
+Add srv-rs to your dependencies in `Cargo.toml`, enabling at least one of
+the DNS resolver backends (see [Alternative Resolvers](README.md#alternative-resolvers-and-target-selection-policies)).
+`trust-dns` is enabled here as an example, but it is not required.
 
 ```toml
 [dependencies]
-srv-rs = { git = "https://github.com/deshaw/srv-rs" }
+srv-rs = { git = "https://github.com/deshaw/srv-rs", features = ["trust-dns"] }
 ```
 
 ## Contributing
@@ -75,8 +84,8 @@ srv-rs = { git = "https://github.com/deshaw/srv-rs" }
 5. Clippy: `cargo clippy`
 6. Bench: `cargo bench`
 7. If modifying crate-level docs (`src/lib.rs`) or `README.tpl`, update `README.md`:
-    1. `cargo install cargo-readme`
-    2. `cargo readme > README.md`
+   1. `cargo install cargo-readme`
+   2. `cargo readme > README.md`
 
 ## History
 

--- a/README.md
+++ b/README.md
@@ -57,22 +57,22 @@ The provided resolver backends are enabled by the following features:
 - `libresolv` (via [`LibResolv`])
 - `trust-dns` (via [`trust-dns-resolver::AsyncResolver`])
 
-[`srvclient::new`]: client/struct.SrvClient.html#method.new
-[`srvclient::execute`]: client/struct.SrvClient.html#method.execute
-[`srvresolver`]: resolver/trait.SrvResolver.html
-[`policy`]: client/policy/trait.Policy.html
-[`libresolv`]: resolver/libresolv/struct.LibResolv.html
-[`trust-dns-resolver::asyncresolver`]: ../trust_dns_resolver/struct.AsyncResolver.html
+[`SrvClient::new`]: client/struct.SrvClient.html#method.new
+[`SrvClient::execute`]: client/struct.SrvClient.html#method.execute
+[`SrvResolver`]: resolver/trait.SrvResolver.html
+[`Policy`]: client/policy/trait.Policy.html
+[`LibResolv`]: resolver/libresolv/struct.LibResolv.html
+[`trust-dns-resolver::AsyncResolver`]: ../trust_dns_resolver/struct.AsyncResolver.html
 
 ## Usage
 
 Add srv-rs to your dependencies in `Cargo.toml`, enabling at least one of
 the DNS resolver backends (see [Alternative Resolvers](README.md#alternative-resolvers-and-target-selection-policies)).
-`trust-dns` is enabled here as an example, but it is not required.
+`libresolv` is enabled here as an example, but it is not required.
 
 ```toml
 [dependencies]
-srv-rs = { git = "https://github.com/deshaw/srv-rs", features = ["trust-dns"] }
+srv-rs = { git = "https://github.com/deshaw/srv-rs", features = ["libresolv"] }
 ```
 
 ## Contributing
@@ -84,8 +84,8 @@ srv-rs = { git = "https://github.com/deshaw/srv-rs", features = ["trust-dns"] }
 5. Clippy: `cargo clippy`
 6. Bench: `cargo bench`
 7. If modifying crate-level docs (`src/lib.rs`) or `README.tpl`, update `README.md`:
-   1. `cargo install cargo-readme`
-   2. `cargo readme > README.md`
+    1. `cargo install cargo-readme`
+    2. `cargo readme > README.md`
 
 ## History
 

--- a/README.tpl
+++ b/README.tpl
@@ -6,11 +6,11 @@
 
 Add {{crate}} to your dependencies in `Cargo.toml`, enabling at least one of
 the DNS resolver backends (see [Alternative Resolvers](README.md#alternative-resolvers-and-target-selection-policies)).
-`trust-dns` is enabled here as an example, but it is not required.
+`libresolv` is enabled here as an example, but it is not required.
 
 ```toml
 [dependencies]
-{{crate}} = { git = "https://github.com/deshaw/{{crate}}", features = ["trust-dns"] }
+{{crate}} = { git = "https://github.com/deshaw/{{crate}}", features = ["libresolv"] }
 ```
 
 ## Contributing

--- a/README.tpl
+++ b/README.tpl
@@ -4,11 +4,13 @@
 
 ## Usage
 
-Add {{crate}} to your dependencies in `Cargo.toml`:
+Add {{crate}} to your dependencies in `Cargo.toml`, enabling at least one of
+the DNS resolver backends (see [Alternative Resolvers](README.md#alternative-resolvers-and-target-selection-policies)).
+`trust-dns` is enabled here as an example, but it is not required.
 
 ```toml
 [dependencies]
-{{crate}} = { git = "https://github.com/deshaw/{{crate}}" }
+{{crate}} = { git = "https://github.com/deshaw/{{crate}}", features = ["trust-dns"] }
 ```
 
 ## Contributing

--- a/benches/resolver.rs
+++ b/benches/resolver.rs
@@ -5,9 +5,10 @@ use trust_dns_resolver::{AsyncResolver, TokioAsyncResolver};
 pub fn criterion_benchmark(c: &mut Criterion) {
     let mut runtime = tokio::runtime::Runtime::new().unwrap();
     let libresolv = LibResolv::default();
-    let trust_dns = runtime
-        .block_on(AsyncResolver::tokio_from_system_conf())
-        .unwrap();
+    // Disable trust-dns caching so benches are fair
+    let (conf, mut opts) = trust_dns_resolver::system_conf::read_system_conf().unwrap();
+    opts.cache_size = 0;
+    let trust_dns = runtime.block_on(AsyncResolver::tokio(conf, opts)).unwrap();
 
     let mut group = c.benchmark_group(format!("resolve {}", srv_rs::EXAMPLE_SRV));
     group.bench_function("libresolv", |b| {

--- a/benches/resolver.rs
+++ b/benches/resolver.rs
@@ -1,34 +1,62 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use srv_rs::resolver::{libresolv::LibResolv, SrvResolver};
+use trust_dns_resolver::{AsyncResolver, TokioAsyncResolver};
 
 pub fn criterion_benchmark(c: &mut Criterion) {
     let mut runtime = tokio::runtime::Runtime::new().unwrap();
+    let libresolv = LibResolv::default();
+    let trust_dns = runtime
+        .block_on(AsyncResolver::tokio_from_system_conf())
+        .unwrap();
 
-    c.bench_function(
-        &format!("resolve {} (libresolv)", srv_rs::EXAMPLE_SRV),
-        |b| {
-            b.iter(|| {
-                runtime
-                    .block_on(LibResolv::default().get_srv_records_unordered(srv_rs::EXAMPLE_SRV))
-                    .unwrap()
-            })
-        },
-    );
-
-    c.bench_function("resolve _imaps._tcp.gmail.com (libresolv)", |b| {
+    let mut group = c.benchmark_group(format!("resolve {}", srv_rs::EXAMPLE_SRV));
+    group.bench_function("libresolv", |b| {
         b.iter(|| {
             runtime
-                .block_on(LibResolv::default().get_srv_records_unordered("_imaps._tcp.gmail.com"))
+                .block_on(libresolv.get_srv_records_unordered(srv_rs::EXAMPLE_SRV))
                 .unwrap()
         })
     });
+    group.bench_function("trust-dns", |b| {
+        b.iter(|| {
+            runtime
+                .block_on(trust_dns.get_srv_records_unordered(srv_rs::EXAMPLE_SRV))
+                .unwrap()
+        })
+    });
+    drop(group);
 
-    let (records, _) = runtime
-        .block_on(LibResolv::default().get_srv_records_unordered(srv_rs::EXAMPLE_SRV))
-        .unwrap();
+    let gmail = "_imaps._tcp.gmail.com";
+    let mut group = c.benchmark_group(format!("resolve {}", gmail));
+    group.bench_function("libresolv", |b| {
+        b.iter(|| {
+            runtime
+                .block_on(libresolv.get_srv_records_unordered(gmail))
+                .unwrap()
+        })
+    });
+    group.bench_function("trust-dns", |b| {
+        b.iter(|| {
+            runtime
+                .block_on(trust_dns.get_srv_records_unordered(gmail))
+                .unwrap()
+        })
+    });
+    drop(group);
+
+    let mut group = c.benchmark_group(format!("order {} records", srv_rs::EXAMPLE_SRV));
     let mut rng = rand::thread_rng();
-    c.bench_function(&format!("order {} records", srv_rs::EXAMPLE_SRV), |b| {
+    let (records, _) = runtime
+        .block_on(libresolv.get_srv_records_unordered(srv_rs::EXAMPLE_SRV))
+        .unwrap();
+    group.bench_function("libresolv", |b| {
         b.iter(|| LibResolv::order_srv_records(&mut records.clone(), &mut rng))
+    });
+    let (records, _) = runtime
+        .block_on(trust_dns.get_srv_records_unordered(srv_rs::EXAMPLE_SRV))
+        .unwrap();
+    group.bench_function("trust-dns", |b| {
+        b.iter(|| TokioAsyncResolver::order_srv_records(&mut records.clone(), &mut rng))
     });
 }
 

--- a/benches/resolver.rs
+++ b/benches/resolver.rs
@@ -23,7 +23,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         })
     });
 
-    let records = runtime
+    let (records, _) = runtime
         .block_on(LibResolv::default().get_srv_records_unordered(srv_rs::EXAMPLE_SRV))
         .unwrap();
     let mut rng = rand::thread_rng();

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -86,10 +86,9 @@ impl<Resolver: Default, Policy: policy::Policy + Default> SrvClient<Resolver, Po
     ///
     /// # Examples
     /// ```
-    /// # use srv_rs::{EXAMPLE_SRV, client::SrvClient, resolver::libresolv::LibResolv};
-    /// # fn main() {
+    /// # use srv_rs::EXAMPLE_SRV;
+    /// use srv_rs::{client::SrvClient, resolver::libresolv::LibResolv};
     /// let client = SrvClient::<LibResolv>::new("_http._tcp.example.com");
-    /// # }
     /// ```
     pub fn new(srv_name: impl ToString) -> Self {
         Self::new_with_resolver(srv_name, Resolver::default())
@@ -320,11 +319,9 @@ impl<Resolver, Policy: policy::Policy> SrvClient<Resolver, Policy> {
     /// # Examples
     ///
     /// ```
-    /// # use srv_rs::{EXAMPLE_SRV, resolver::libresolv::LibResolv};
-    /// # use srv_rs::client::{SrvClient, policy::Rfc2782};
-    /// # fn main() {
+    /// # use srv_rs::{EXAMPLE_SRV, };
+    /// use srv_rs::{client::{SrvClient, policy::Rfc2782}, resolver::libresolv::LibResolv};
     /// let client = SrvClient::<LibResolv>::new(EXAMPLE_SRV).policy(Rfc2782);
-    /// # }
     /// ```
     pub fn policy<P: policy::Policy>(self, policy: P) -> SrvClient<Resolver, P> {
         SrvClient {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -210,6 +210,7 @@ impl<Resolver: SrvResolver, Policy: policy::Policy> SrvClient<Resolver, Policy> 
         };
         let results = match execution_mode {
             Execution::Serial => stream::iter(order).then(func).left_stream(),
+            #[allow(clippy::from_iter_instead_of_collect)]
             Execution::Concurrent => {
                 stream::FuturesUnordered::from_iter(order.map(func)).right_stream()
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,15 +51,22 @@ first `Ok` or last `Err` it obtains.
 
 # Alternative Resolvers and Target Selection Policies
 
-`srv-rs` provides a `libresolv`-based resolver for SRV lookup and by default uses a
-target selection policy that maintains affinity for the last target it has used
-successfully. Both of these behaviors can be changed by implementing the
+`srv-rs` provides multiple resolver backends for SRV lookup and by default uses
+a target selection policy that maintains affinity for the last target it has
+used successfully. Both of these behaviors can be changed by implementing the
 [`SrvResolver`] and [`Policy`] traits, respectively.
+
+The provided resolver backends are enabled by the following features:
+
+- `libresolv` (via [`LibResolv`])
+- `trust-dns` (via [`trust-dns-resolver::AsyncResolver`])
 
 [`SrvClient::new`]: client/struct.SrvClient.html#method.new
 [`SrvClient::execute`]: client/struct.SrvClient.html#method.execute
 [`SrvResolver`]: resolver/trait.SrvResolver.html
 [`Policy`]: client/policy/trait.Policy.html
+[`LibResolv`]: resolver/libresolv/struct.LibResolv.html
+[`trust-dns-resolver::AsyncResolver`]: ../trust_dns_resolver/struct.AsyncResolver.html
 */
 
 pub mod client;

--- a/src/record.rs
+++ b/src/record.rs
@@ -2,15 +2,19 @@
 
 use http::uri::{PathAndQuery, Scheme, Uri};
 use rand::Rng;
-use std::{cmp::Reverse, convert::TryFrom, time::Duration};
+use std::{cmp::Reverse, convert::TryFrom, fmt::Display, time::Duration};
 
 /// Representation of types that contain the fields of a SRV record.
 pub trait SrvRecord {
+    /// Type representing the SRV record's target. Must implement `Display` so
+    /// it can be used to create a `Uri`.
+    type Target: Display + ?Sized;
+
     /// Gets a SRV record's time-to-live.
     fn ttl(&self) -> Duration;
 
     /// Gets a SRV record's target.
-    fn target(&self) -> &str;
+    fn target(&self) -> &Self::Target;
 
     /// Gets a SRV record's port.
     fn port(&self) -> u16;

--- a/src/record.rs
+++ b/src/record.rs
@@ -2,16 +2,13 @@
 
 use http::uri::{PathAndQuery, Scheme, Uri};
 use rand::Rng;
-use std::{cmp::Reverse, convert::TryFrom, fmt::Display, time::Duration};
+use std::{cmp::Reverse, convert::TryFrom, fmt::Display};
 
 /// Representation of types that contain the fields of a SRV record.
 pub trait SrvRecord {
     /// Type representing the SRV record's target. Must implement `Display` so
     /// it can be used to create a `Uri`.
     type Target: Display + ?Sized;
-
-    /// Gets a SRV record's time-to-live.
-    fn ttl(&self) -> Duration;
 
     /// Gets a SRV record's target.
     fn target(&self) -> &Self::Target;
@@ -37,7 +34,6 @@ pub trait SrvRecord {
     ///     weight: 100,
     ///     port: 8211,
     ///     target: String::from("srv-client-rust.deshaw.org"),
-    ///     ttl: Duration::from_secs(60),
     /// };
     /// assert_eq!(
     ///     &record.parse("https", "/")?.to_string(),

--- a/src/resolver/libresolv/mod.rs
+++ b/src/resolver/libresolv/mod.rs
@@ -2,7 +2,12 @@
 
 use super::{SrvRecord, SrvResolver};
 use async_trait::async_trait;
-use std::{convert::TryInto, ffi::CString, time::Duration};
+use std::{
+    cmp,
+    convert::TryInto,
+    ffi::CString,
+    time::{Duration, Instant},
+};
 
 mod ffi;
 
@@ -49,7 +54,10 @@ impl SrvResolver for LibResolv {
     type Record = LibResolvSrvRecord;
     type Error = LibResolvError;
 
-    async fn get_srv_records_unordered(&self, srv: &str) -> Result<Vec<Self::Record>, Self::Error> {
+    async fn get_srv_records_unordered(
+        &self,
+        srv: &str,
+    ) -> Result<(Vec<Self::Record>, Instant), Self::Error> {
         let srv = CString::new(srv)?;
         let mut buf = vec![0u8; self.initial_buf_size];
         ffi::RESOLV_STATE.with(|state| {
@@ -86,16 +94,20 @@ impl SrvResolver for LibResolv {
             state.check(ret)?;
 
             let mut rr = unsafe { std::mem::zeroed() };
-            let records = (0..ffi::ns_msg_count(msg, ffi::ns_s_an))
-                .map(|idx| {
-                    let ret =
-                        unsafe { ffi::ns_parserr(&mut msg, ffi::ns_s_an, idx as i32, &mut rr) };
-                    state.check(ret)?;
-                    LibResolvSrvRecord::try_parse(&state, msg, rr)
-                })
-                .collect::<Result<Vec<_>, _>>()?;
+            let num_records = ffi::ns_msg_count(msg, ffi::ns_s_an);
+            let mut records = Vec::with_capacity(num_records as usize);
+            let mut min_valid_until = None;
+            for idx in 0..num_records {
+                let ret = unsafe { ffi::ns_parserr(&mut msg, ffi::ns_s_an, idx as i32, &mut rr) };
+                state.check(ret)?;
+                let (record, valid_until) = LibResolvSrvRecord::try_parse(&state, msg, rr)?;
+                records.push(record);
+                min_valid_until = min_valid_until
+                    .map(|min_valid_until| cmp::min(min_valid_until, valid_until))
+                    .or(Some(valid_until));
+            }
 
-            Ok(records)
+            Ok((records, min_valid_until.unwrap_or_else(Instant::now)))
         })
     }
 }
@@ -105,8 +117,6 @@ impl SrvResolver for LibResolv {
 /// [`LibResolv`]: struct.LibResolv.html
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct LibResolvSrvRecord {
-    /// Record's time-to-live.
-    pub ttl: Duration,
     /// Records's target.
     pub target: String,
     /// Record's port.
@@ -119,10 +129,6 @@ pub struct LibResolvSrvRecord {
 
 impl SrvRecord for LibResolvSrvRecord {
     type Target = str;
-
-    fn ttl(&self) -> Duration {
-        self.ttl
-    }
 
     fn target(&self) -> &Self::Target {
         &self.target
@@ -146,7 +152,7 @@ impl LibResolvSrvRecord {
         state: &ffi::ResolverState,
         msg: ffi::ns_msg,
         rr: ffi::ns_rr,
-    ) -> Result<Self, LibResolvError> {
+    ) -> Result<(Self, Instant), LibResolvError> {
         if rr.type_ as u32 != ffi::ns_t_srv {
             return Err(LibResolvError::NotSrv);
         }
@@ -175,13 +181,14 @@ impl LibResolvSrvRecord {
         state.check(ret)?;
 
         let target = unsafe { std::ffi::CStr::from_ptr(name.as_ptr().cast()) };
-        Ok(Self {
-            ttl: Duration::from_secs(rr.ttl as u64),
+        let valid_until = Instant::now() + Duration::from_secs(rr.ttl as u64);
+        let record = Self {
             target: target.to_string_lossy().to_string(),
             port,
             priority,
             weight,
-        })
+        };
+        Ok((record, valid_until))
     }
 }
 
@@ -190,17 +197,18 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn test_srv_lookup() -> Result<(), LibResolvError> {
-        let records = LibResolv::default()
+    async fn srv_lookup() -> Result<(), LibResolvError> {
+        let (records, valid_until) = LibResolv::default()
             .get_srv_records_unordered(crate::EXAMPLE_SRV)
             .await?;
         assert_ne!(records.len(), 0);
+        assert!(valid_until > Instant::now());
         Ok(())
     }
 
     #[tokio::test]
-    async fn test_srv_lookup_ordered() -> Result<(), LibResolvError> {
-        let records = LibResolv::default()
+    async fn srv_lookup_ordered() -> Result<(), LibResolvError> {
+        let (records, _) = LibResolv::default()
             .get_srv_records(crate::EXAMPLE_SRV)
             .await?;
         assert_ne!(records.len(), 0);

--- a/src/resolver/libresolv/mod.rs
+++ b/src/resolver/libresolv/mod.rs
@@ -118,11 +118,13 @@ pub struct LibResolvSrvRecord {
 }
 
 impl SrvRecord for LibResolvSrvRecord {
+    type Target = str;
+
     fn ttl(&self) -> Duration {
         self.ttl
     }
 
-    fn target(&self) -> &str {
+    fn target(&self) -> &Self::Target {
         &self.target
     }
 

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -7,6 +7,9 @@ use rand::Rng;
 #[cfg(feature = "libresolv")]
 pub mod libresolv;
 
+#[cfg(feature = "trust-dns")]
+pub mod trust_dns;
+
 /// Represents the ability to act as a SRV resolver.
 #[async_trait]
 pub trait SrvResolver: Send + Sync {

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -3,6 +3,7 @@
 use crate::record::SrvRecord;
 use async_trait::async_trait;
 use rand::Rng;
+use std::time::Instant;
 
 #[cfg(feature = "libresolv")]
 pub mod libresolv;
@@ -20,15 +21,23 @@ pub trait SrvResolver: Send + Sync {
     type Error: std::error::Error + 'static;
 
     /// Gets the records corresponding to a srv name without sorting by priority
-    /// or shuffling based on weight.
-    async fn get_srv_records_unordered(&self, srv: &str) -> Result<Vec<Self::Record>, Self::Error>;
+    /// or shuffling based on weight, returning them along with the time they're
+    /// valid until.
+    async fn get_srv_records_unordered(
+        &self,
+        srv: &str,
+    ) -> Result<(Vec<Self::Record>, Instant), Self::Error>;
 
     /// Gets the records corresponding to a srv name, sorting by priority and
-    /// shuffling based on weight.
-    async fn get_srv_records(&self, srv: &str) -> Result<Vec<Self::Record>, Self::Error> {
-        let mut records = self.get_srv_records_unordered(srv).await?;
+    /// shuffling based on weight, returning them along with the time they're
+    /// valid until.
+    async fn get_srv_records(
+        &self,
+        srv: &str,
+    ) -> Result<(Vec<Self::Record>, Instant), Self::Error> {
+        let (mut records, valid_until) = self.get_srv_records_unordered(srv).await?;
         Self::order_srv_records(&mut records, rand::thread_rng());
-        Ok(records)
+        Ok((records, valid_until))
     }
 
     /// Sorts SRV records by priority and weight per RFC 2782.

--- a/src/resolver/trust_dns.rs
+++ b/src/resolver/trust_dns.rs
@@ -1,0 +1,131 @@
+//! SRV resolver backed by `trust-dns-resolver`.
+
+use super::SrvResolver;
+use crate::record::SrvRecord;
+use async_trait::async_trait;
+use std::time::{Duration, Instant};
+use trust_dns_resolver::{
+    error::ResolveError,
+    proto::{rr::rdata::SRV, DnsHandle},
+    AsyncResolver, ConnectionProvider, Name,
+};
+
+#[async_trait]
+impl<C, P> SrvResolver for AsyncResolver<C, P>
+where
+    C: DnsHandle,
+    P: ConnectionProvider<Conn = C>,
+{
+    type Record = (SRV, Duration);
+    type Error = ResolveError;
+
+    async fn get_srv_records_unordered(&self, srv: &str) -> Result<Vec<Self::Record>, Self::Error> {
+        let lookup = self.srv_lookup(srv).await?;
+        // TODO: it'd be cleaner not to duplicate this duration--maybe we should
+        // have the method return (Vec<Self::Record>, Duration).
+        let ttl = lookup.as_lookup().valid_until() - Instant::now();
+        Ok(lookup.into_iter().zip(std::iter::repeat(ttl)).collect())
+    }
+}
+
+impl SrvRecord for (SRV, Duration) {
+    type Target = Name;
+
+    fn ttl(&self) -> Duration {
+        self.1
+    }
+
+    fn target(&self) -> &Self::Target {
+        self.0.target()
+    }
+
+    fn port(&self) -> u16 {
+        self.0.port()
+    }
+
+    fn priority(&self) -> u16 {
+        self.0.priority()
+    }
+
+    fn weight(&self) -> u16 {
+        self.0.weight()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn srv_lookup() -> Result<(), ResolveError> {
+        let records = AsyncResolver::tokio_from_system_conf()
+            .await?
+            .get_srv_records_unordered(crate::EXAMPLE_SRV)
+            .await?;
+        assert_ne!(records.len(), 0);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn srv_lookup_ordered() -> Result<(), ResolveError> {
+        let records = AsyncResolver::tokio_from_system_conf()
+            .await?
+            .get_srv_records(crate::EXAMPLE_SRV)
+            .await?;
+        assert_ne!(records.len(), 0);
+        assert!((0..records.len() - 1).all(|i| records[i].priority() <= records[i + 1].priority()));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn get_fresh_uris() -> Result<(), ResolveError> {
+        use crate::client::{policy::Affinity, SrvClient};
+        let resolver = AsyncResolver::tokio_from_system_conf().await?;
+        let client = SrvClient::<_, Affinity>::new_with_resolver(crate::EXAMPLE_SRV, resolver);
+        assert_ne!(
+            client.get_fresh_uri_candidates().await.unwrap().0,
+            Vec::<http::Uri>::new()
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn invalid_host() {
+        AsyncResolver::tokio_from_system_conf()
+            .await
+            .unwrap()
+            .get_srv_records("_http._tcp.foobar.deshaw.com")
+            .await
+            .unwrap_err();
+    }
+
+    #[tokio::test]
+    async fn malformed_srv_name() {
+        AsyncResolver::tokio_from_system_conf()
+            .await
+            .unwrap()
+            .get_srv_records("_http.foobar.deshaw.com")
+            .await
+            .unwrap_err();
+    }
+
+    #[tokio::test]
+    async fn very_malformed_srv_name() {
+        AsyncResolver::tokio_from_system_conf()
+            .await
+            .unwrap()
+            .get_srv_records("  @#*^[_hsd flt.com")
+            .await
+            .unwrap_err();
+    }
+
+    #[tokio::test]
+    async fn srv_name_containing_nul_terminator() {
+        AsyncResolver::tokio_from_system_conf()
+            .await
+            .unwrap()
+            .get_srv_records("_http.\0_tcp.foo.com")
+            .await
+            .unwrap_err();
+    }
+}

--- a/src/resolver/trust_dns.rs
+++ b/src/resolver/trust_dns.rs
@@ -76,9 +76,8 @@ mod tests {
 
     #[tokio::test]
     async fn get_fresh_uris() -> Result<(), ResolveError> {
-        use crate::client::{policy::Affinity, SrvClient};
         let resolver = AsyncResolver::tokio_from_system_conf().await?;
-        let client = SrvClient::<_, Affinity>::new_with_resolver(crate::EXAMPLE_SRV, resolver);
+        let client = crate::client::SrvClient::<_>::new_with_resolver(crate::EXAMPLE_SRV, resolver);
         let (uris, _) = client.get_fresh_uri_candidates().await.unwrap();
         assert_ne!(uris, Vec::<http::Uri>::new());
         Ok(())


### PR DESCRIPTION
Adds support for `trust-dns-resolver`, a popular in-process DNS resolver, as a backend. I anticipate some users of `srv-rs` will want to use it, and I wanted to make sure it's actually feasible to add backends. The process motivated:

- disabling the `libresolv` feature by default to not be preferential towards any backend
- switching to using an `Instant` to represent the time a cache is valid until, instead of a `Duration` for which it is valid
  - should've been doing this all along
- removing `SrvRecord::ttl`  and only requiring that resolvers give us a time the new items are valid until
  - for whatever reason, many resolvers don't like providing SRV TTLs
  - we don't actually care about TTLs on a per-record basis, we only need enough information to pick a reasonable lifetime for the cache
- loosening the requirement on the type of SRV targets produced by records to anything that implements `Display`, since that's all we're relying on and they might not be stored as something `impl AsRef<str>`