### PR TITLE
Module structure and documentation cleanup

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: dtolnay/rust-toolchain@clippy
-      - run: cargo clippy --tests -- -Dclippy::all
+      - run: cargo clippy --all-features --tests -- -Dclippy::all
 
   cargo-readme:
     runs-on: ubuntu-16.04

--- a/README.md
+++ b/README.md
@@ -68,17 +68,17 @@ the DNS resolver backends (see [Alternative Resolvers](README.md#alternative-res
 
 ```toml
 [dependencies]
-srv-rs = { git = "https://github.com/deshaw/srv-rs", features = ["libresolv"] }
+srv-rs = { version = "0.1.1", features = ["libresolv"] }
 ```
 
 ## Contributing
 
 1. Clone the repo
 2. Make some changes
-3. Test: `cargo test`
+3. Test: `cargo test --all-features`
 4. Format: `cargo fmt`
-5. Clippy: `cargo clippy`
-6. Bench: `cargo bench`
+5. Clippy: `cargo clippy --all-features --tests -- -Dclippy::all`
+6. Bench: `cargo bench --all-features`
 7. If modifying crate-level docs (`src/lib.rs`) or `README.tpl`, update `README.md`:
     1. `cargo install cargo-readme`
     2. `cargo readme > README.md`

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ selection of targets to use for communication with SRV-located services.
 It presents this service in the following interface:
 
 ```rust
-use srv_rs::{client::{SrvClient, Execution}, resolver::libresolv::LibResolv};
+use srv_rs::{SrvClient, Execution, resolver::libresolv::LibResolv};
 let client = SrvClient::<LibResolv>::new("_http._tcp.example.com");
 client.execute(Execution::Serial, |address: http::Uri| async move {
     // Communicate with the service at `address`
@@ -57,7 +57,8 @@ The provided resolver backends are enabled by the following features:
 - `libresolv` (via [`LibResolv`])
 - `trust-dns` (via [`trust_dns_resolver::AsyncResolver`])
 
-[`Policy`]: client::policy::Policy
+[`SrvResolver`]: resolver::SrvResolver
+[`Policy`]: policy::Policy
 [`LibResolv`]: resolver::libresolv::LibResolv
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ The provided resolver backends are enabled by the following features:
 
 [`SrvClient::new`]: client::SrvClient::new()
 [`SrvClient::execute`]: client::SrvClient::execute()
-[`SrvResolver`]: resolver::SrvResolver
 [`Policy`]: client::policy::Policy
 [`LibResolv`]: resolver::libresolv::LibResolv
 

--- a/README.md
+++ b/README.md
@@ -57,8 +57,6 @@ The provided resolver backends are enabled by the following features:
 - `libresolv` (via [`LibResolv`])
 - `trust-dns` (via [`trust_dns_resolver::AsyncResolver`])
 
-[`SrvClient::new`]: client::SrvClient::new()
-[`SrvClient::execute`]: client::SrvClient::execute()
 [`Policy`]: client::policy::Policy
 [`LibResolv`]: resolver::libresolv::LibResolv
 

--- a/README.tpl
+++ b/README.tpl
@@ -10,17 +10,17 @@ the DNS resolver backends (see [Alternative Resolvers](README.md#alternative-res
 
 ```toml
 [dependencies]
-{{crate}} = { git = "https://github.com/deshaw/{{crate}}", features = ["libresolv"] }
+{{crate}} = { version = "{{version}}", features = ["libresolv"] }
 ```
 
 ## Contributing
 
 1. Clone the repo
 2. Make some changes
-3. Test: `cargo test`
+3. Test: `cargo test --all-features`
 4. Format: `cargo fmt`
-5. Clippy: `cargo clippy`
-6. Bench: `cargo bench`
+5. Clippy: `cargo clippy --all-features --tests -- -Dclippy::all`
+6. Bench: `cargo bench --all-features`
 7. If modifying crate-level docs (`src/lib.rs`) or `README.tpl`, update `README.md`:
     1. `cargo install cargo-readme`
     2. `cargo readme > README.md`

--- a/benches/client.rs
+++ b/benches/client.rs
@@ -1,9 +1,6 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use rand::Rng;
-use srv_rs::{
-    client::{policy::Rfc2782, Execution, SrvClient},
-    resolver::libresolv::LibResolv,
-};
+use srv_rs::{policy::Rfc2782, resolver::libresolv::LibResolv, Execution, SrvClient};
 
 const SRV_NAME: &str = srv_rs::EXAMPLE_SRV;
 const SRV_DESCRIPTION: &str = SRV_NAME;

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,6 +1,6 @@
 //! Clients based on SRV lookups.
 
-use crate::{record::SrvRecord, resolver::SrvResolver};
+use crate::{resolver::SrvResolver, SrvRecord};
 use arc_swap::ArcSwap;
 use futures_util::{
     pin_mut,

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -10,8 +10,8 @@ use futures_util::{
 use http::uri::{Scheme, Uri};
 use std::{error::Error, fmt::Debug, future::Future, iter::FromIterator, sync::Arc, time::Instant};
 
-pub mod cache;
-use cache::Cache;
+mod cache;
+pub use cache::Cache;
 
 /// SRV target selection policies.
 pub mod policy;

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -81,8 +81,7 @@ impl<Resolver: Default, Policy: policy::Policy + Default> SrvClient<Resolver, Po
     ///
     /// # Examples
     /// ```
-    /// # use srv_rs::EXAMPLE_SRV;
-    /// use srv_rs::{client::SrvClient, resolver::libresolv::LibResolv};
+    /// use srv_rs::{SrvClient, resolver::libresolv::LibResolv};
     /// let client = SrvClient::<LibResolv>::new("_http._tcp.example.com");
     /// ```
     pub fn new(srv_name: impl ToString) -> Self {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,6 +1,6 @@
 //! Clients based on SRV lookups.
 
-use crate::{resolver::SrvResolver, SrvRecord};
+use crate::{SrvRecord, SrvResolver};
 use arc_swap::ArcSwap;
 use futures_util::{
     pin_mut,

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,6 +1,6 @@
 //! Clients based on SRV lookups.
 
-use crate::{SrvRecord, SrvResolver};
+use crate::{resolver::SrvResolver, SrvRecord};
 use arc_swap::ArcSwap;
 use futures_util::{
     pin_mut,
@@ -163,14 +163,15 @@ impl<Resolver: SrvResolver, Policy: policy::Policy> SrvClient<Resolver, Policy> 
     /// # Examples
     ///
     /// ```
-    /// # use srv_rs::{EXAMPLE_SRV, client::{SrvClient, SrvError, Execution}};
-    /// # use srv_rs::resolver::libresolv::{LibResolv, LibResolvError};
-    /// # use std::convert::Infallible;
+    /// # use srv_rs::EXAMPLE_SRV;
+    /// use srv_rs::{SrvClient, SrvError, Execution};
+    /// use srv_rs::resolver::libresolv::{LibResolv, LibResolvError};
+    ///
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), SrvError<LibResolvError>> {
     /// # let client = SrvClient::<LibResolv>::new(EXAMPLE_SRV);
     /// let results_stream = client.execute_stream(Execution::Serial, |address| async move {
-    ///     Ok::<_, Infallible>(address.to_string())
+    ///     Ok::<_, std::convert::Infallible>(address.to_string())
     /// })
     /// .await?;
     /// // Do something with the stream, for example collect all results into a `Vec`:
@@ -236,15 +237,16 @@ impl<Resolver: SrvResolver, Policy: policy::Policy> SrvClient<Resolver, Policy> 
     /// # Examples
     ///
     /// ```
-    /// # use srv_rs::{EXAMPLE_SRV, client::{SrvClient, SrvError, Execution}};
-    /// # use srv_rs::resolver::libresolv::{LibResolv, LibResolvError};
-    /// # use std::convert::Infallible;
+    /// # use srv_rs::EXAMPLE_SRV;
+    /// use srv_rs::{SrvClient, SrvError, Execution};
+    /// use srv_rs::resolver::libresolv::{LibResolv, LibResolvError};
+    ///
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), SrvError<LibResolvError>> {
     /// let client = SrvClient::<LibResolv>::new(EXAMPLE_SRV);
     ///
     /// let res = client.execute(Execution::Serial, |address| async move {
-    ///     Ok::<_, Infallible>(address.to_string())
+    ///     Ok::<_, std::convert::Infallible>(address.to_string())
     /// })
     /// .await?;
     /// assert!(res.is_ok());
@@ -314,8 +316,8 @@ impl<Resolver, Policy: policy::Policy> SrvClient<Resolver, Policy> {
     /// # Examples
     ///
     /// ```
-    /// # use srv_rs::{EXAMPLE_SRV, };
-    /// use srv_rs::{client::{SrvClient, policy::Rfc2782}, resolver::libresolv::LibResolv};
+    /// # use srv_rs::EXAMPLE_SRV;
+    /// use srv_rs::{SrvClient, policy::Rfc2782, resolver::libresolv::LibResolv};
     /// let client = SrvClient::<LibResolv>::new(EXAMPLE_SRV).policy(Rfc2782);
     /// ```
     pub fn policy<P: policy::Policy>(self, policy: P) -> SrvClient<Resolver, P> {

--- a/src/client/policy.rs
+++ b/src/client/policy.rs
@@ -1,8 +1,10 @@
-use crate::client::{Cache, SrvClient, SrvError, SrvRecord, SrvResolver};
+use crate::{resolver::SrvResolver, SrvClient, SrvError, SrvRecord};
 use arc_swap::ArcSwapOption;
 use async_trait::async_trait;
 use http::Uri;
 use std::sync::Arc;
+
+pub use super::Cache;
 
 /// Policy for [`SrvClient`] to use when selecting SRV targets to recommend.
 #[async_trait]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,13 +62,12 @@ The provided resolver backends are enabled by the following features:
 - `libresolv` (via [`LibResolv`])
 - `trust-dns` (via [`trust_dns_resolver::AsyncResolver`])
 
-[`SrvClient::new`]: client::SrvClient::new()
-[`SrvClient::execute`]: client::SrvClient::execute()
 [`Policy`]: client::policy::Policy
 [`LibResolv`]: resolver::libresolv::LibResolv
 */
 
 pub mod client;
+pub use client::SrvClient;
 
 mod record;
 pub use record::SrvRecord;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,6 @@ The provided resolver backends are enabled by the following features:
 
 [`SrvClient::new`]: client::SrvClient::new()
 [`SrvClient::execute`]: client::SrvClient::execute()
-[`SrvResolver`]: resolver::SrvResolver
 [`Policy`]: client::policy::Policy
 [`LibResolv`]: resolver::libresolv::LibResolv
 */
@@ -75,6 +74,7 @@ mod record;
 pub use record::SrvRecord;
 
 pub mod resolver;
+pub use resolver::SrvResolver;
 
 #[doc(hidden)]
 pub const EXAMPLE_SRV: &str = "_http._tcp.srv-client-rust.deshaw.org";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ It presents this service in the following interface:
 ```
 # #[tokio::main]
 # async fn main() {
-use srv_rs::{client::{SrvClient, Execution}, resolver::libresolv::LibResolv};
+use srv_rs::{SrvClient, Execution, resolver::libresolv::LibResolv};
 let client = SrvClient::<LibResolv>::new("_http._tcp.example.com");
 client.execute(Execution::Serial, |address: http::Uri| async move {
     // Communicate with the service at `address`
@@ -62,18 +62,18 @@ The provided resolver backends are enabled by the following features:
 - `libresolv` (via [`LibResolv`])
 - `trust-dns` (via [`trust_dns_resolver::AsyncResolver`])
 
-[`Policy`]: client::policy::Policy
+[`SrvResolver`]: resolver::SrvResolver
+[`Policy`]: policy::Policy
 [`LibResolv`]: resolver::libresolv::LibResolv
 */
 
-pub mod client;
-pub use client::SrvClient;
+mod client;
+pub use client::{policy, Execution, SrvClient, SrvError};
 
 mod record;
 pub use record::SrvRecord;
 
 pub mod resolver;
-pub use resolver::SrvResolver;
 
 #[doc(hidden)]
 pub const EXAMPLE_SRV: &str = "_http._tcp.srv-client-rust.deshaw.org";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,8 @@ The provided resolver backends are enabled by the following features:
 
 pub mod client;
 
-pub mod record;
+mod record;
+pub use record::SrvRecord;
 
 pub mod resolver;
 

--- a/src/record.rs
+++ b/src/record.rs
@@ -27,8 +27,7 @@ pub trait SrvRecord {
     ///
     /// ```
     /// # fn srv_record_parse() -> Result<(), http::Error> {
-    /// # use std::time::Duration;
-    /// # use srv_rs::{resolver::libresolv::LibResolvSrvRecord, record::SrvRecord};
+    /// use srv_rs::{resolver::libresolv::LibResolvSrvRecord, SrvRecord};
     /// let record = LibResolvSrvRecord {
     ///     priority: 1,
     ///     weight: 100,
@@ -67,7 +66,7 @@ pub trait SrvRecord {
 }
 
 /// Generates a key to sort a SRV record by priority and weight per RFC 2782.
-pub fn sort_key(priority: u16, weight: u16, mut rng: impl Rng) -> (u16, Reverse<u32>) {
+pub(crate) fn sort_key(priority: u16, weight: u16, mut rng: impl Rng) -> (u16, Reverse<u32>) {
     // Sort ascending by priority, then descending (hence `Reverse`) by randomized weight
     let rand = rng.gen::<u16>() as u32;
     (priority, Reverse(weight as u32 * rand))

--- a/src/resolver/libresolv/mod.rs
+++ b/src/resolver/libresolv/mod.rs
@@ -1,6 +1,7 @@
 //! SRV Resolver backed by `libresolv`.
 
-use super::{SrvRecord, SrvResolver};
+use super::SrvResolver;
+use crate::SrvRecord;
 use async_trait::async_trait;
 use std::{
     convert::TryInto,

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -9,7 +9,7 @@ use std::time::Instant;
 pub mod libresolv;
 
 #[cfg(feature = "trust-dns")]
-pub mod trust_dns;
+mod trust_dns;
 
 /// Represents the ability to act as a SRV resolver.
 #[async_trait]

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -1,6 +1,6 @@
 //! SRV resolvers.
 
-use crate::record::SrvRecord;
+use crate::SrvRecord;
 use async_trait::async_trait;
 use rand::Rng;
 use std::time::Instant;

--- a/src/resolver/trust_dns.rs
+++ b/src/resolver/trust_dns.rs
@@ -1,7 +1,7 @@
 //! SRV resolver backed by [`trust_dns_resolver`].
 
 use super::SrvResolver;
-use crate::record::SrvRecord;
+use crate::SrvRecord;
 use async_trait::async_trait;
 use std::time::Instant;
 use trust_dns_resolver::{

--- a/src/resolver/trust_dns.rs
+++ b/src/resolver/trust_dns.rs
@@ -77,7 +77,7 @@ mod tests {
     #[tokio::test]
     async fn get_fresh_uris() -> Result<(), ResolveError> {
         let resolver = AsyncResolver::tokio_from_system_conf().await?;
-        let client = crate::client::SrvClient::<_>::new_with_resolver(crate::EXAMPLE_SRV, resolver);
+        let client = crate::SrvClient::<_>::new_with_resolver(crate::EXAMPLE_SRV, resolver);
         let (uris, _) = client.get_fresh_uri_candidates().await.unwrap();
         assert_ne!(uris, Vec::<http::Uri>::new());
         Ok(())


### PR DESCRIPTION
* Flattened `crate::client` and `crate::record` modules in public API
* Exported `Cache` from `crate::policy`
* Hid empty `crate::resolver::trust_dns` module
* Updated README contributing section and `crates.io` dependency