### PR TITLE
Use resolv dependency from crates.io

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,7 +33,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y bubblewrap
           echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
-          cargo install bindgen-cli
       - name: Run tests
         run: |
           # It is not possible to run all the tests in a single
@@ -63,9 +62,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-      - name: Environment
-        run: |
-          cargo install bindgen-cli
       - name: Clippy
         run: |
           cargo clippy \
@@ -85,9 +81,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - name: Environment
-        run: |
-          cargo install bindgen-cli
       - name: Documentation
         run: |
           cargo doc \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.1 - 2026-04-16
+
+### Changed
+
+- Replaced pinned git dependency for `resolv` crate with crates.io release
+- Removed `bindgen-cli` requirement from CI workflows
+
+### Fixed
+
+- Clippy lint for duration construction in test DNS server
+
 ## 1.0.0 - 2026-04-08
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "srv-rs"
-version = "1.0.0"
+version = "1.0.1"
 authors = [
     "The D. E. Shaw Group <opensource@deshaw.com>",
     "Max Heller <max.a.heller@gmail.com>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,11 +33,7 @@ http = "1.4.0"
 rand = { version = "0.9.2", default-features = false, features = [
     'thread_rng',
 ] }
-# As of 2026-01-28, version 0.4 of resolv has not been released but is the only
-# version building with current versions of bindgen-cli [0]
-#
-# [0] https://github.com/mikedilger/resolv-rs/issues/11
-resolv = { version = "0.4", git = "https://github.com/mikedilger/resolv-rs.git", rev = "a0349cb", optional = true }
+resolv = { version = "0.4", optional = true }
 thiserror = { version = "2.0.17", default-features = false }
 tracing = { version = "0.1.43", optional = true }
 hickory-resolver = { version = "0.25", optional = true }

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ the DNS resolver backends (see [Alternative Resolvers](README.md#alternative-res
 
 ```toml
 [dependencies]
-srv-rs = { version = "1.0.0", features = ["hickory"] }
+srv-rs = { version = "1.0.1", features = ["hickory"] }
 ```
 
 ## Contributing

--- a/tests/sandbox/components/dns.rs
+++ b/tests/sandbox/components/dns.rs
@@ -90,7 +90,7 @@ impl MockDns {
         }
 
         let socket = UdpSocket::bind(Self::BIND_ADDR)?;
-        socket.set_read_timeout(Some(Duration::from_millis(1000)))?;
+        socket.set_read_timeout(Some(Duration::from_secs(1)))?;
         let shutdown = Arc::new(AtomicBool::new(false));
         let shutdown_clone = Arc::clone(&shutdown);
         let records = self.records.clone();


### PR DESCRIPTION
The 0.4 versions of `resolv` and `libresolv` are on crates.io now (see https://github.com/mikedilger/resolv-rs/issues/11). This updates Cargo.toml accordingly.  